### PR TITLE
Review and document deprecation warnings status

### DIFF
--- a/DEPRECATION_REVIEW.md
+++ b/DEPRECATION_REVIEW.md
@@ -1,0 +1,32 @@
+# Deprecation Warning Review
+
+## Summary
+This document summarizes the review of deprecation warnings in the ODEInterfaceDiffEq.jl package as of January 2025.
+
+## Findings
+
+### Dependency Deprecation Warning
+During testing, the following warning appears:
+```
+┌ Warning: `@mtkbuild` is deprecated. Use `@mtkcompile` instead.
+│   caller = ip:0x0
+└ @ Core :-1
+```
+
+This warning originates from the **ODEProblemLibrary** dependency, not from ODEInterfaceDiffEq.jl itself.
+
+### ODEInterfaceDiffEq.jl Source Code Review
+- ✅ No deprecation warnings in the package's own source code
+- ✅ No usage of deprecated Julia language features
+- ✅ No usage of `@mtkbuild` or other deprecated macros
+
+## Conclusion
+ODEInterfaceDiffEq.jl itself contains no deprecation warnings. The package is up-to-date with current Julia practices. The `@mtkbuild` deprecation warning is from a test dependency (ODEProblemLibrary) and does not affect the package's core functionality.
+
+## Recommendation
+The deprecation warning should be addressed in the ODEProblemLibrary package, not in ODEInterfaceDiffEq.jl.
+
+## CI Status
+✅ Tests pass successfully
+✅ No deprecation warnings in package source code
+⚠️ Dependency deprecation warning present (not actionable in this package)


### PR DESCRIPTION
## Summary
Reviewed CI logs and test output for deprecation warnings in ODEInterfaceDiffEq.jl.

## Findings
- No deprecation warnings in ODEInterfaceDiffEq.jl source code
- `@mtkbuild` deprecation warning comes from ODEProblemLibrary dependency, not this package
- Package is up-to-date with current Julia practices

## Changes
- Added `DEPRECATION_REVIEW.md` documenting investigation results
- Confirmed all tests pass successfully

## Notes
The `@mtkbuild` deprecation should be addressed in ODEProblemLibrary, not here.

## Test plan
- [x] Ran full test suite locally  
- [x] Confirmed no deprecation warnings in package source
- [x] Verified CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)