### PR TITLE
Support SciMLBase v3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ODEInterfaceDiffEq"
 uuid = "09606e27-ecf5-54fc-bb29-004bd9f985bf"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "3.17.0"
+version = "3.18.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
@@ -20,7 +20,7 @@ DiffEqBase = "6.122"
 FunctionWrappers = "1.0"
 ODEInterface = "0.5"
 Reexport = "0.2, 1.0"
-SciMLBase = "1.73, 2"
+SciMLBase = "1.73, 2, 3.1"
 julia = "1.6"
 
 [extras]

--- a/src/integrator_utils.jl
+++ b/src/integrator_utils.jl
@@ -99,6 +99,18 @@ end
     return integrator.u_modified = bool
 end
 
+# SciMLBase v3 renamed `u_modified!` → `derivative_discontinuity!`. On v3+,
+# also provide the overload under the new name so callers using the new
+# API dispatch correctly for `ODEInterfaceIntegrator` instead of hitting
+# the generic `error(...)` fallback in `SciMLBase.derivative_discontinuity!`.
+@static if isdefined(SciMLBase, :derivative_discontinuity!)
+    @inline function SciMLBase.derivative_discontinuity!(
+            integrator::ODEInterfaceIntegrator, bool::Bool
+        )
+        return integrator.u_modified = bool
+    end
+end
+
 function initialize_callbacks!(integrator, initialize_save = true)
     t = integrator.t
     u = integrator.u


### PR DESCRIPTION
## Summary

Courtesy PR for the SciMLBase v3 release.

- Extend `SciMLBase` compat to `"1.73, 2, 3.1"` (keep existing lower bound and v2 support).
- Bump version to 3.18.0.
- Add a `SciMLBase.derivative_discontinuity!(::ODEInterfaceIntegrator, ::Bool)` overload in `src/integrator_utils.jl` alongside the existing `DiffEqBase.u_modified!` method, guarded by `@static if isdefined(SciMLBase, :derivative_discontinuity!)`.

SciMLBase v3 renamed `u_modified!` → `derivative_discontinuity!` with an `@deprecate` shim on the old name (`src/integrator_interface.jl:242` in SciMLBase). The existing `u_modified!` overload for `ODEInterfaceIntegrator` still dispatches for legacy callers, but any caller migrated to the new name would otherwise hit the generic `error("method has not been implemented for the integrator")` fallback. The `isdefined` guard keeps the file compiling on SciMLBase v2.

## Known limitation

Local tests cannot be run: `Pkg.resolve()` fails on any env containing SciMLBase 3.1 because `OrdinaryDiffEq` in the registry still pins `RecursiveArrayTools ≤ 3.54`. Expect CI to fail at the `Pkg.add` step until upstream bumps.

## Reference pattern

Same `@static if isdefined(SciMLBase, :derivative_discontinuity!)` shim used in SciML/DiffEqCallbacks.jl#300.

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)