### PR TITLE
Bump DiffEqBase compat to include v7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ODEInterfaceDiffEq"
 uuid = "09606e27-ecf5-54fc-bb29-004bd9f985bf"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "3.19.0"
+version = "3.20.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
@@ -17,7 +17,7 @@ SciMLLogging = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
 [compat]
 Compat = "2.2, 3.0, 4"
 DataStructures = "0.18, 0.19"
-DiffEqBase = "6.217"
+DiffEqBase = "6.217, 7"
 FunctionWrappers = "1.0"
 ODEInterface = "0.5"
 Reexport = "0.2, 1.0"


### PR DESCRIPTION
## Summary

Widen `DiffEqBase = "6.217"` → `"6.217, 7"` so ODEInterfaceDiffEq resolves alongside `lib/DiffEqBase` v7 (OrdinaryDiffEq v7 release). Bumps 3.19.0 → 3.20.0.

Already-OK: `SciMLBase = "1.73, 2, 3.1"`.

## Why this is source-level safe

`DiffEqBase.u_modified!(integrator::ODEInterfaceIntegrator, bool)` at `src/integrator_utils.jl:98` continues to work via SciMLBase v3's `@deprecate u_modified!(i, bool) derivative_discontinuity!(i, bool)` (scheduled removal 2028). The file already has a `# SciMLBase v3 renamed …` comment at line 102, so the maintainer was already tracking the rename; method-adding to a `@deprecate`d function is still valid Julia. Will emit a deprecation warning on v3 — mechanical swap to `SciMLBase.derivative_discontinuity!` is a reasonable follow-up.

No hits for `has_destats`, `.destats`, `concrete_solve`, `fastpow`, `RECOMPILE_BY_DEFAULT`, `DEStats`, `QuadratureProblem`, `tuples()`/`intervals()`, standalone `DEAlgorithm`/`DEProblem`/`DESolution`.

## Scope

Part of the v7-compat-widening set alongside DiffEqCallbacks#303, DiffEqNoiseProcess#271, DiffEqProblemLibrary#182, JumpProcesses#580, ModelingToolkit#4467, StateSelection#71, ParameterizedFunctions#151, SciMLSensitivity#1431, Sundials#526.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>