### PR TITLE
Bump major version for SciMLBase v3 / DiffEqBase v7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ODEInterfaceDiffEq"
 uuid = "09606e27-ecf5-54fc-bb29-004bd9f985bf"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "3.20.0"
+version = "4.0.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"


### PR DESCRIPTION
## Summary

The SciMLBase v3 / DiffEqBase v7 / OrdinaryDiffEq v7 release is **breaking** across the ecosystem (typed `verbose` / `DEVerbosity` instead of `Bool`, `AutoSpecialize` `ODEFunction` default, controllers as objects, RAT v4, removed re-exports, etc. — see [the OrdinaryDiffEq v7 NEWS.md](https://github.com/SciML/OrdinaryDiffEq.jl/blob/master/NEWS.md)). Adding v3 compat in a non-major release was a SemVer mistake — users on the previous major could silently end up with v3 ecosystem behavior they did not opt into.

The prior v3-allowing minor/patch releases on this package are being yanked from General in https://github.com/JuliaRegistries/General/pull/153846. This PR bumps the major version so users opt into v3 explicitly.

The package source already runs against both the v2 and v3 ecosystems (compat covers both), so no code changes are needed — this is a version-only bump.

## Test plan
- [ ] CI green
- [ ] After merge, register with `@JuliaRegistrator register()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)