### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
-      - "/test"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -11,22 +11,11 @@ on:
     paths-ignore:
       - 'docs/**'
 jobs:
-  test:
+  downgrade:
     if: false  # Disabled: waiting on OrdinaryDiffEq updates. See #87 for details.
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    name: "Downgrade"
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -5,9 +5,5 @@ on: [pull_request]
 jobs:
   typos-check:
     name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts the remaining inline CI checks to the centralized SciML reusable workflows (`@v1`, every caller gets `secrets: "inherit"`). End-state matches the Sundials.jl model.

## Converted (inline -> central)
- **FormatCheck.yml**: `fredrikekre/runic-action` -> `runic.yml@v1`
- **SpellCheck.yml**: `crate-ci/typos` -> `spellcheck.yml@v1`
- **Downgrade.yml**: inline downgrade job -> `downgrade.yml@v1`, preserving `julia-version: "1.10"`, `skip: "Pkg,TOML"`, and the existing disabling `if: false` (waiting on OrdinaryDiffEq updates, see #87)

## Already central
- **Tests.yml**: already a `tests.yml@v1` caller with `secrets: "inherit"` and the `version: ["lts"]` matrix — left unchanged.

## Not applicable
- No `docs/` directory -> no Documentation caller.
- No existing Downstream/Benchmark/CompatHelper workflows -> none added/removed.

## Cleanup
- **dependabot.yml**: removed the `crate-ci/typos` ignore entry (no longer needed now that typos is centralized); julia ecosystem block now covers `/` only, since `/test` has no `Project.toml`.

## Notes
- `name:`/`on:`/concurrency of each workflow preserved.
- Runic: ran locally, repo already clean (no formatting changes).
- typos: ran locally, clean (0 fixes). `.typos.toml` retained as-is.
- TagBot.yml left unchanged.

## Heads up
Check names change (jobs now run under the reusable workflows), so any branch-protection **required status checks** will need to be updated to match the new check names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)