### PR TITLE
ci: re-enable downgrade CI with corrected [compat] lower bounds

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,7 +12,6 @@ on:
       - 'docs/**'
 jobs:
   downgrade:
-    if: false  # Disabled: waiting on OrdinaryDiffEq updates. See #87 for details.
     name: "Downgrade"
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -17,4 +17,5 @@ jobs:
     with:
       julia-version: "1.10"
       skip: "Pkg,TOML"
+      mode: "deps"
     secrets: "inherit"

--- a/Project.toml
+++ b/Project.toml
@@ -15,13 +15,13 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SciMLLogging = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
 
 [compat]
-Compat = "2.2, 3.0, 4"
-DataStructures = "0.18, 0.19"
+Compat = "4.15"
+DataStructures = "0.19"
 DiffEqBase = "6.217, 7"
-FunctionWrappers = "1.0"
+FunctionWrappers = "1.1.3"
 ODEInterface = "0.5"
-Reexport = "0.2, 1.0"
-SciMLBase = "1.73, 2, 3.1"
+Reexport = "1.2.2"
+SciMLBase = "2.154, 3.1"
 SciMLLogging = "1.10.1, 2"
 julia = "1.6"
 


### PR DESCRIPTION
Re-enables the disabled Downgrade workflow (removes the `if: false` guard) and replaces the previous, self-contradictory `[compat]` lower bounds with clean, minimal, verified ones.

## What was wrong before

The earlier floors could not resolve on the downgrade run, and the "fixes" left comma-ranges that re-permitted versions below the intended floor (e.g. `Compat = "4.18.1, 3.0, 4"`, `SciMLBase = "2.155.1, 2, 3.1"`, `Reexport = "1.2.2, 1.0"`, `DataStructures = "0.19.5, 0.19"`). Those lower ranges defeat the bump, and the floors were also raised to the latest patch rather than the lowest working version.

## Corrected bounds (lowest that resolve + pass on Julia 1.10)

```
Compat:           "2.2, 3.0, 4"  -> "4.15"        # NonlinearSolveBase requires Compat >= 4.15
DataStructures:   "0.18, 0.19"   -> "0.19"        # 0.18 too old for the ModelingToolkit/SymbolicUtils stack
FunctionWrappers: "1.0"          -> "1.1.3"       # 1.1.1 fails to precompile ("Module IR does not contain specified entry function"); 1.1.3 fixes it
Reexport:         "0.2, 1.0"     -> "1.2.2"       # BracketingNonlinearSolve requires Reexport >= 1.2.2
SciMLBase:        "1.73, 2, 3.1" -> "2.154, 3.1"  # DiffEqBase 6.217 needs FunctionWrappersWrappers 1, which SciMLBase provides from 2.154
```

Why the lower ranges had to be dropped: `DiffEqBase = "6.217, 7"` (its existing floor) already forces `SciMLBase >= 2.143` and `FunctionWrappersWrappers = 1`; `SciMLBase 1.73`/`2.0` can never resolve against that, so the `1.73` and the `< 2.154` part of the `2` range are dead. The disjoint upper `3.1` range (DiffEqBase 7 / SciMLBase 3 era) is kept since it is above the floor and genuinely declared.

`DiffEqBase`, `ODEInterface`, and `SciMLLogging` floors are unchanged. `julia = "1.6"` is kept, and the workflow `julia-version` stays `1.10`.

## Verification

Reproduced the downgrade locally on Julia 1.10.11 in an isolated depot by pinning every non-stdlib dep to its compat floor, then iterating to the lowest resolvable + test-passing set. Full `Pkg.test()` at the pinned floors:

```
Explicit Imports         | Pass 2/2
Algorithms               | ran (no assertions)
Saving                   | Pass 3/3
Mass Matrix              | Pass 4/4
Jacobian Tests           | Pass 1/1
Callback Tests           | Pass 2/2
Initialization Tests     | Pass 13/13
MTK Initialization Tests | Pass 55/55
Testing ODEInterfaceDiffEq tests passed
```

Local downgrade suite on Julia 1.10: **PASS**.

> Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
