### PR TITLE
Rename `u_modified` integrator field to `derivative_discontinuity`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ODEInterfaceDiffEq"
 uuid = "09606e27-ecf5-54fc-bb29-004bd9f985bf"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "4.1.0"
+version = "5.0.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
@@ -17,11 +17,11 @@ SciMLLogging = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
 [compat]
 Compat = "2.2, 3.0, 4"
 DataStructures = "0.18, 0.19"
-DiffEqBase = "6.217, 7"
+DiffEqBase = "7"
 FunctionWrappers = "1.0"
 ODEInterface = "0.5"
 Reexport = "0.2, 1.0"
-SciMLBase = "1.73, 2, 3.1"
+SciMLBase = "3.1"
 SciMLLogging = "1.10.1, 2"
 julia = "1.6"
 

--- a/src/initialize.jl
+++ b/src/initialize.jl
@@ -158,7 +158,7 @@ function DiffEqBase.initialize_dae!(
         copyto!(old_vals, new_vals)
     end
 
-    integrator.u_modified = true
+    integrator.derivative_discontinuity = true
 
     return nothing
 end

--- a/src/integrator_types.jl
+++ b/src/integrator_types.jl
@@ -17,7 +17,7 @@ mutable struct ODEInterfaceIntegrator{
     tprev::Float64
     p::P
     opts::oType
-    u_modified::Bool
+    derivative_discontinuity::Bool
     tdir::Float64
     sizeu::SType
     sol::solType

--- a/src/integrator_utils.jl
+++ b/src/integrator_utils.jl
@@ -42,7 +42,7 @@ function handle_callbacks!(integrator, eval_sol_fcn)
         savevalues!(integrator)
     end
 
-    return integrator.u_modified = continuous_modified || discrete_modified
+    return integrator.derivative_discontinuity = continuous_modified || discrete_modified
 end
 
 function DiffEqBase.savevalues!(
@@ -96,7 +96,7 @@ DiffEqBase.get_tmp_cache(i::ODEInterfaceIntegrator, args...) = nothing
 end
 
 @inline function DiffEqBase.u_modified!(integrator::ODEInterfaceIntegrator, bool::Bool)
-    return integrator.u_modified = bool
+    return integrator.derivative_discontinuity = bool
 end
 
 # SciMLBase v3 renamed `u_modified!` → `derivative_discontinuity!`. On v3+,
@@ -107,7 +107,7 @@ end
     @inline function SciMLBase.derivative_discontinuity!(
             integrator::ODEInterfaceIntegrator, bool::Bool
         )
-        return integrator.u_modified = bool
+        return integrator.derivative_discontinuity = bool
     end
 end
 
@@ -115,7 +115,7 @@ function initialize_callbacks!(integrator, initialize_save = true)
     t = integrator.t
     u = integrator.u
     callbacks = integrator.opts.callback
-    integrator.u_modified = true
+    integrator.derivative_discontinuity = true
 
     u_modified = initialize!(callbacks, u, t, integrator)
 
@@ -131,7 +131,7 @@ function initialize_callbacks!(integrator, initialize_save = true)
     end
 
     # reset this as it is now handled so the integrators should proceed as normal
-    return integrator.u_modified = false
+    return integrator.derivative_discontinuity = false
 end
 
 DiffEqBase.set_proposed_dt!(integrator::ODEInterfaceIntegrator, dt) = nothing

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -473,7 +473,7 @@ function (f::OutputFunction)(
 
         handle_callbacks!(integrator, eval_sol_fcn)
 
-        if integrator.u_modified
+        if integrator.derivative_discontinuity
             if eltype(integrator.sol.u) <: Vector
                 u .= integrator.u
             else


### PR DESCRIPTION
## Problem

On the latest dependency resolution (SciMLBase v3 / DiffEqBase v7), `Pkg.test()` failed in the Callback Tests with:

```
type ODEInterfaceIntegrator has no field derivative_discontinuity
  [1] getproperty @ src/integrator_utils.jl
  [2] initialize! @ DiffEqBase/src/callbacks.jl
  ...
  test/callbacks.jl:23  (ContinuousCallback solve with dopri5)
```

## Root cause

SciMLBase v3 renamed the `u_modified!` API to `derivative_discontinuity!`, and DiffEqBase v7's callback machinery now reads **and writes the integrator field** `derivative_discontinuity` directly (`callbacks.jl` `initialize!`/`finalize!`/`apply_discrete_callback!`/`apply_callback!` all do `integrator.derivative_discontinuity` and `integrator.derivative_discontinuity = ...`). `ODEInterfaceIntegrator` only had a `u_modified` field.

## Fix (per review)

Rather than aliasing through `getproperty`/`setproperty!`, **rename the struct field itself** `u_modified` → `derivative_discontinuity` so it matches the SciMLBase v3 / DiffEqBase v7 convention. The `getproperty` override is back to only special-casing `:dt`; the custom `setproperty!` is removed. `DiffEqBase.u_modified!` and `SciMLBase.derivative_discontinuity!` both set the renamed field.

Files changed:
- `src/integrator_types.jl` — field `u_modified::Bool` → `derivative_discontinuity::Bool`.
- `src/integrator_utils.jl` — revert `getproperty` to `:dt`-only + `getfield`; remove the custom `setproperty!`; rename internal field refs; both setter methods now assign `derivative_discontinuity`.
- `src/solve.jl`, `src/initialize.jl` — rename the remaining field refs.
- `Project.toml` — compat bump + version bump (see below).

The constructor call in `solve.jl` is positional, so the rename does not affect it. The only remaining `u_modified` mentions are the `DiffEqBase.u_modified!` **function** name (a SciMLBase/DiffEqBase API name that simply sets the renamed field) and a local variable.

## Compat (determined empirically)

Renaming the field commits to the SciMLBase v3 field name, so SciMLBase v1/v2 support is dropped. This was verified, not assumed:

- DiffEqBase v6.218.0 (which pairs with SciMLBase v2) reads `integrator.u_modified` **directly** in its callback machinery.
- With the rename and no alias, running the Callback test under SciMLBase v2.155.1 / DiffEqBase 6.218.0 errors with `type ODEInterfaceIntegrator has no field u_modified` (at DiffEqBase `callbacks.jl` `initialize!`).
- DiffEqBase `[7]` requires `SciMLBase = "3"` (registry compat), and DiffEqBase v7 is the version that uses the `derivative_discontinuity` field.

So compat is bumped:
- `SciMLBase = "1.73, 2, 3.1"` -> `SciMLBase = "3.1"`
- `DiffEqBase = "6.217, 7"` -> `DiffEqBase = "7"`

Package version bumped `4.1.0` -> `5.0.0` (breaking, since a supported dependency major is dropped).

## Testing

Full `Pkg.test()` run locally on Julia 1.10 at latest deps (SciMLBase v3.18.0 / DiffEqBase v7.5.5), with the bumped compat in place:

```
Explicit Imports         | Pass  2  Total  2
Algorithms               | None
Saving                   | Pass  3  Total  3
Mass Matrix              | Pass  4  Total  4
Jacobian Tests           | Pass  1  Total  1
Callback Tests           | Pass  2  Total  2
Initialization Tests     | Pass 13  Total 13
MTK Initialization Tests | Pass 55  Total 55
     Testing ODEInterfaceDiffEq tests passed
```

Callback Tests go from Error (before) to 2/2 Pass (after); no new failures. Runic v1.7.0 reports no changes on the edited `.jl` files.

> Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
