### PR TITLE
Canonicalize test units to @safetestset

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,6 +26,7 @@ ODEInterface = "0.5"
 ODEProblemLibrary = "1"
 Pkg = "1"
 Reexport = "1.2.2"
+SafeTestsets = "0.1, 1"
 SciMLBase = "3.1"
 SciMLLogging = "1.10.1, 2"
 SymbolicIndexingInterface = "0.3"
@@ -38,8 +39,9 @@ ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 ODEProblemLibrary = "fdc4e326-1af4-4b90-96e7-779fcce2daa5"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ExplicitImports", "ModelingToolkit", "NonlinearSolve", "SymbolicIndexingInterface", "Test", "ODEProblemLibrary", "Pkg"]
+test = ["ExplicitImports", "ModelingToolkit", "NonlinearSolve", "SafeTestsets", "SymbolicIndexingInterface", "Test", "ODEProblemLibrary", "Pkg"]

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -2,6 +2,7 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 ODEInterfaceDiffEq = "09606e27-ecf5-54fc-bb29-004bd9f985bf"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
@@ -10,5 +11,6 @@ ODEInterfaceDiffEq = { path = "../.." }
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
+SafeTestsets = "0.1, 1"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,7 +1,7 @@
-using ODEInterfaceDiffEq, Aqua, JET
-using Test
+using SafeTestsets
 
-@testset "Aqua" begin
+@safetestset "Aqua" begin
+    using ODEInterfaceDiffEq, Aqua, Test
     # deps_compat disabled: ODEInterfaceDiffEq does not declare a compat entry
     # for the LinearAlgebra stdlib dependency. Tracked in
     # https://github.com/SciML/ODEInterfaceDiffEq.jl/issues/105
@@ -9,7 +9,8 @@ using Test
     @test_broken false  # Aqua deps compat: missing compat entry for LinearAlgebra dep — tracked in https://github.com/SciML/ODEInterfaceDiffEq.jl/issues/105
 end
 
-@testset "JET" begin
+@safetestset "JET" begin
+    using ODEInterfaceDiffEq, JET, Test
     # JET.test_package reports an undefined-binding error
     # (ODEInterfaceDiffEq.uBottomEltype in src/solve.jl). Tracked in
     # https://github.com/SciML/ODEInterfaceDiffEq.jl/issues/105

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,31 +1,31 @@
 using ODEInterfaceDiffEq, DiffEqBase
-using Test
+using SafeTestsets, Test
 
 const GROUP = get(ENV, "GROUP", "All")
 
 if GROUP == "All" || GROUP == "Core"
-    @time @testset "Explicit Imports" begin
+    @time @safetestset "Explicit Imports" begin
         include("explicit_imports.jl")
     end
-    @time @testset "Algorithms" begin
+    @time @safetestset "Algorithms" begin
         include("algorithm_tests.jl")
     end
-    @time @testset "Saving" begin
+    @time @safetestset "Saving" begin
         include("saving_tests.jl")
     end
-    @time @testset "Mass Matrix" begin
+    @time @safetestset "Mass Matrix" begin
         include("mass_matrix_tests.jl")
     end
-    @time @testset "Jacobian Tests" begin
+    @time @safetestset "Jacobian Tests" begin
         include("jac_tests.jl")
     end
-    @time @testset "Callback Tests" begin
+    @time @safetestset "Callback Tests" begin
         include("callbacks.jl")
     end
-    @time @testset "Initialization Tests" begin
+    @time @safetestset "Initialization Tests" begin
         include("initialization_tests.jl")
     end
-    @time @testset "MTK Initialization Tests" begin
+    @time @safetestset "MTK Initialization Tests" begin
         include("mtk_initialization_tests.jl")
     end
 end


### PR DESCRIPTION
Wraps each independent top-level test unit in `@safetestset` so it runs in its own module, matching OrdinaryDiffEq's canonical structure (isolation between units + world-age safety). Behavior-preserving: the same units run under the same `GROUP` dispatch with the same assertions — only the unit wrapper changes.

## Changes
- **`test/runtests.jl`**: the 8 Core units `@testset "X" begin include("x.jl") end` become `@safetestset "X" begin include("x.jl") end`. Each included file (`algorithm_tests.jl`, `saving_tests.jl`, `mass_matrix_tests.jl`, `jac_tests.jl`, `callbacks.jl`, `initialization_tests.jl`, `mtk_initialization_tests.jl`, `explicit_imports.jl`) is already self-contained with its own `using`/`import` lines, and the `include()` form runs statements sequentially so imports (and package macros like ModelingToolkit's `@variables`/`@mtkcompile`) resolve correctly inside the fresh module.
- **`test/qa/qa.jl`**: the `Aqua` and `JET` units become `@safetestset`, each carrying its own `using ODEInterfaceDiffEq, <Tool>, Test`. The existing `@test_broken` lines (tracked in #105) are preserved verbatim. The outer `@testset "Quality Assurance"` grouping wrapper in `runtests.jl` is left as-is.
- **Deps**: added `SafeTestsets` to the main `Project.toml` `[extras]` + `[targets].test` + `[compat] SafeTestsets = "0.1, 1"`, and to `test/qa/Project.toml` (the QA group activates its own env).

The `GROUP`-dispatch ladder, run path, and all assertions are unchanged. Nested grouping `@testset`s inside a unit (e.g. the per-`iip`/per-`alg` testsets in the initialization files) stay plain `@testset` — the unit-level `@safetestset` already isolates them.

## Verification
`GROUP=Core` run **locally** via `Pkg.test` (Julia 1.11) — passed:

```
Explicit Imports |    2      2
Algorithms       |     0           (exercises solve() calls, no @test — unchanged)
Saving           |    3      3
Mass Matrix      |    4      4
Jacobian Tests   |    1      1
Callback Tests   |    2      2
Initialization Tests     |   13     13
MTK Initialization Tests |   55     55
     Testing ODEInterfaceDiffEq tests passed
```

Ignore until reviewed by @ChrisRackauckas.