### PR TITLE
Drop ODEInterfaceDiffEq QA self source

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -6,9 +6,6 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-ODEInterfaceDiffEq = { path = "../.." }
-
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.**

## Summary

- Remove the redundant `ODEInterfaceDiffEq = { path = "../.." }` `[sources]` entry from `test/qa/Project.toml`.
- Keep the SciMLTesting 2.1 QA setup otherwise unchanged.

## Verification

- `rg -n "^\[sources\]|path\s*=" test/qa/Project.toml` returned no matches.
- `timeout 3600 env GROUP=QA /home/crackauc/.juliaup/bin/julia +release --project=. --startup-file=no -e 'using Pkg; Pkg.test(; coverage=false)'`\n  - passed: `QA/qa.jl | 19/19`.\n