### PR TITLE
Release prep: bump to 5.2.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ODEInterfaceDiffEq"
 uuid = "09606e27-ecf5-54fc-bb29-004bd9f985bf"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "5.2.0"
+version = "5.2.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"


### PR DESCRIPTION
Version-bump-only release PR. Real bug fixes (undefined uBottomEltype, dead elseif branch, unhandled negative retcodes now map to ReturnCode.Failure instead of crashing) plus the standard DiffEqBase->SciMLBase solver-extension-point migration used elsewhere in SciML.