### PR TITLE
Release prep: bump version to 5.2.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ODEInterfaceDiffEq"
 uuid = "09606e27-ecf5-54fc-bb29-004bd9f985bf"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "5.2.1"
+version = "5.2.2"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"


### PR DESCRIPTION
## Summary

Bumps the package version from 5.2.1 to 5.2.2 to release unreleased commits sitting on top of the last registered version.

Last registered version 5.2.1 corresponds to commit 8904acf (its root tree-sha1 exactly matches the `Versions.toml` entry in the General registry). Since then, one commit has landed on `master`:

- bde5e26 — Drop ODEInterfaceDiffEq QA self source (#112): removes a `[sources]` override (`ODEInterfaceDiffEq = { path = "../.." }`) from `test/qa/Project.toml`. This is a test/QA-tooling-only change — no source files, no exported API, and no `[compat]` bounds were touched.

## Bump type: PATCH (5.2.1 -> 5.2.2)

Chosen because the only change since the last release is to test infrastructure (`test/qa/Project.toml`), with no changes to package source code, public API, or dependency compat bounds.

## Compat bounds

No changes to `[compat]` were needed — the diff since 5.2.1 does not touch dependency usage or the main `Project.toml` `[compat]` section.