### PR TITLE
Restore the documented SciML common interface as explicit exports

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,3 +12,32 @@ rodas
 ddeabm
 ddebdf
 ```
+
+## Reexported SciML common interface
+
+`using ODEInterfaceDiffEq` also brings in the parts of the SciML common interface needed
+to build a problem, solve it with one of the solvers above, and inspect the result, so
+they do not have to be imported separately. These names are owned and documented by
+[SciMLBase](https://docs.sciml.ai/SciMLBase/stable/) and
+[DiffEqBase](https://docs.sciml.ai/DiffEqDocs/stable/) — `DefaultInit` comes from
+DiffEqBase, everything else from SciMLBase:
+
+  - Problems: `ODEProblem`, `EnsembleProblem`
+  - Functions: `ODEFunction`
+  - Solutions: `ODESolution`, `EnsembleSolution`, `EnsembleSummary`, `DEStats`
+  - Ensemble algorithms: `EnsembleSerial`, `EnsembleThreads`, `EnsembleDistributed`,
+    `EnsembleSplitThreads`, and the `EnsembleAnalysis` module
+  - Solving: `solve`, `solve!`, `init`, `step!`, `remake`
+  - Integrator interface: `DEIntegrator`, `savevalues!`, `change_t_via_interpolation!`,
+    `get_tmp_cache`, `set_proposed_dt!`, `u_modified!`, `terminate!`
+  - Return status: `ReturnCode`, `successful_retcode`
+  - Callbacks: `ContinuousCallback`, `DiscreteCallback`, `VectorContinuousCallback`,
+    `CallbackSet`, `DECallback`
+  - Initialization algorithms: `DefaultInit`, `NoInit`, `CheckInit`, `OverrideInit`
+  - `NullParameters`
+
+The integrator functions listed above are exactly the ones ODEInterfaceDiffEq implements
+methods for, and the initialization algorithms are exactly the ones it implements
+`initialize_dae!` for. `BrownFullBasicInit` and `ShampineCollocationInit` are
+deliberately not reexported, since they have no method here. Anything else from SciMLBase
+or DiffEqBase must be imported from that package directly.

--- a/src/ODEInterfaceDiffEq.jl
+++ b/src/ODEInterfaceDiffEq.jl
@@ -11,10 +11,24 @@ module ODEInterfaceDiffEq
     import SciMLStructures
     using DataStructures: BinaryMaxHeap, BinaryMinHeap, counter
     using LinearAlgebra: I
-    using SciMLBase: CallbackSet, ReturnCode, VectorContinuousCallback, check_keywords,
-        warn_compat
+    using SciMLBase: check_keywords, warn_compat
     using SciMLLogging: SciMLLogging, @SciMLMessage
     import DiffEqBase: initialize!, savevalues!
+
+    # The SciML common interface that ODEInterfaceDiffEq reexports (see the second
+    # `export` below), so that `using ODEInterfaceDiffEq` on its own is enough to build
+    # an ODE problem, solve it with one of the ODEInterface solvers, drive the
+    # integrator from a callback, and inspect the result -- which is exactly what the
+    # README example does. The integrator functions listed here are the ones this
+    # package implements methods for. Every name stays owned and documented upstream.
+    using SciMLBase: CallbackSet, CheckInit, ContinuousCallback, DECallback, DEIntegrator,
+        DEStats, DiscreteCallback, EnsembleAnalysis, EnsembleDistributed, EnsembleProblem,
+        EnsembleSerial, EnsembleSolution, EnsembleSplitThreads, EnsembleSummary,
+        EnsembleThreads, NoInit, NullParameters, ODEFunction, ODEProblem, ODESolution,
+        OverrideInit, ReturnCode, VectorContinuousCallback, change_t_via_interpolation!,
+        get_tmp_cache, init, remake, set_proposed_dt!, solve, solve!, step!,
+        successful_retcode, terminate!, u_modified!
+    using DiffEqBase: DefaultInit
 
     const warnkeywords = (
         :save_idxs, :d_discontinuities, :unstable_check, :tstops,
@@ -48,5 +62,15 @@ module ODEInterfaceDiffEq
 
     export ODEInterfaceAlgorithm, dopri5, dop853, odex, seulex, radau, radau5, rodas,
         ddeabm, ddebdf
+
+    # Reexported SciML common interface; approved via `reexports_allow` in test/qa/qa.jl.
+    export CallbackSet, CheckInit, ContinuousCallback, DECallback, DEIntegrator,
+        DEStats, DefaultInit, DiscreteCallback, EnsembleAnalysis, EnsembleDistributed,
+        EnsembleProblem, EnsembleSerial, EnsembleSolution, EnsembleSplitThreads,
+        EnsembleSummary, EnsembleThreads, NoInit, NullParameters, ODEFunction, ODEProblem,
+        ODESolution, OverrideInit, ReturnCode, VectorContinuousCallback,
+        change_t_via_interpolation!, get_tmp_cache, init, remake, savevalues!,
+        set_proposed_dt!, solve, solve!, step!, successful_retcode, terminate!,
+        u_modified!
 
 end # module

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,3 +1,27 @@
-using ODEInterfaceDiffEq, SciMLTesting
+using ODEInterfaceDiffEq, SciMLTesting, Test
 
-run_qa(ODEInterfaceDiffEq)
+# The SciML common interface ODEInterfaceDiffEq deliberately reexports so that
+# `using ODEInterfaceDiffEq` is enough to build and solve an ODE problem, as the README
+# example does. Owned and documented upstream; kept in sync with the reexport `export`
+# block in src/ODEInterfaceDiffEq.jl.
+const REEXPORTS = (
+    :CallbackSet, :CheckInit, :ContinuousCallback, :DECallback, :DEIntegrator,
+    :DEStats, :DefaultInit, :DiscreteCallback, :EnsembleAnalysis, :EnsembleDistributed,
+    :EnsembleProblem, :EnsembleSerial, :EnsembleSolution, :EnsembleSplitThreads,
+    :EnsembleSummary, :EnsembleThreads, :NoInit, :NullParameters, :ODEFunction,
+    :ODEProblem, :ODESolution, :OverrideInit, :ReturnCode, :VectorContinuousCallback,
+    :change_t_via_interpolation!, :get_tmp_cache, :init, :remake, :savevalues!,
+    :set_proposed_dt!, :solve, :solve!, :step!, :successful_retcode, :terminate!,
+    :u_modified!,
+)
+
+run_qa(ODEInterfaceDiffEq; reexports_allow = REEXPORTS)
+
+@testset "Reexport surface" begin
+    # Every approved reexport must actually be reachable from `using ODEInterfaceDiffEq`,
+    # so the allow-list cannot drift into approving names the package no longer provides.
+    @testset "$name" for name in REEXPORTS
+        @test name in names(ODEInterfaceDiffEq)
+        @test isdefined(@__MODULE__, name)
+    end
+end


### PR DESCRIPTION
## What broke

`d732fae` ("Require documented ODEInterface wrapper API", #116) removed
`@reexport using DiffEqBase` from `src/ODEInterfaceDiffEq.jl`.

That reexport *was* this package's common-interface surface. Without it, `using
ODEInterfaceDiffEq` no longer brings `ODEProblem`, `solve`, `ReturnCode` or the
callbacks into scope, so the README's own Lorenz example fails with
`UndefVarError`:

```julia
using ODEInterface, ODEInterfaceDiffEq
ODEInterface.loadODESolvers()
prob = ODEProblem(lorenz, u0, tspan)   # UndefVarError: `ODEProblem` not defined
sol = solve(prob, dopri5(), abstol = 1e-4)
```

Before this PR `names(ODEInterfaceDiffEq)` was 11 entries: the algorithms and
nothing else. CI stayed green because the same commit added `using DiffEqBase` to
`test/callbacks.jl` — which is itself direct evidence that those names used to
come from the reexport.

## What this PR does

Per the org rule ("reexport what is normal documented use, but not whole
dependencies"), this follows SciML/Sundials.jl#553: not a restored blanket
reexport, but an explicit `export` list.

## Evidence used to pick the names

1. `README.md` — the only usage example, `using ODEInterface, ODEInterfaceDiffEq`
   then `ODEProblem` + `solve` + solution indexing.
2. `test/` — `test/callbacks.jl` had `using DiffEqBase` *added* by the stripping
   commit; the other test files use `ODEProblem`, `ODEFunction`, `ReturnCode`,
   `successful_retcode`, `ContinuousCallback` after `using ODEInterfaceDiffEq,
   DiffEqBase`.
3. `src/` — which integrator hooks and DAE-initialization algorithms this package
   actually implements methods for (`src/integrator_utils.jl`,
   `src/initialize.jl`). Names with no method here are excluded: they error
   identically before and after.

## Restored names (36)

`CallbackSet`, `CheckInit`, `ContinuousCallback`, `DECallback`, `DEIntegrator`,
`DEStats`, `DefaultInit`, `DiscreteCallback`, `EnsembleAnalysis`,
`EnsembleDistributed`, `EnsembleProblem`, `EnsembleSerial`, `EnsembleSolution`,
`EnsembleSplitThreads`, `EnsembleSummary`, `EnsembleThreads`, `NoInit`,
`NullParameters`, `ODEFunction`, `ODEProblem`, `ODESolution`, `OverrideInit`,
`ReturnCode`, `VectorContinuousCallback`, `change_t_via_interpolation!`,
`get_tmp_cache`, `init`, `remake`, `savevalues!`, `set_proposed_dt!`, `solve`,
`solve!`, `step!`, `successful_retcode`, `terminate!`, `u_modified!`

Deliberately excluded: `BrownFullBasicInit` / `ShampineCollocationInit` (no
`initialize_dae!` method here), integrator hooks with no `ODEInterfaceIntegrator`
method (`add_tstop!`, `reinit!`, `get_du`, `check_error`, …), and the
SDE/DDE/BVP/optimization surface DiffEqBase carried along — ~160 names that stay
dropped.

Every name is imported from its owning module (SciMLBase, except `DefaultInit`
which DiffEqBase owns), so each stays documented upstream.

## Drift protection

`test/qa/qa.jl` declares the same list via `reexports_allow`, and a new testset
asserts every approved name is both in `names(ODEInterfaceDiffEq)` and actually
in scope from `using ODEInterfaceDiffEq`.

## Semver

Non-breaking. This only re-adds names that `using ODEInterfaceDiffEq` provided
before `d732fae`; no existing name changes meaning and nothing is removed. Minor
bump. Version intentionally not bumped here — a separate release pass handles it.

## Verification run locally

- `Pkg.test()` — full suite green (Core: algorithm, callbacks, initialization,
  jac, mass matrix, MTK initialization, saving).
- `using ODEInterfaceDiffEq` then the README-shaped `ODEProblem` + `solve` +
  `successful_retcode` flow with no other import — works;
  `names(ODEInterfaceDiffEq)` goes 11 → 47.
- `test/qa/qa.jl` — the reexport testset and "No unapproved public reexports"
  pass. One pre-existing error remains in `all_qualified_accesses_are_public`
  (`Base.Iterators.filter` at `src/solve.jl:338`); it reproduces identically on
  `master` with the SciMLTesting version installed here (2.11 vs. the 2.4 pinned
  in `test/qa/Project.toml`) and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ